### PR TITLE
Update scripts to use command line options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,26 @@ Both first level keys have the same set of subkeys:
 #### Standard Column Naming
 The state source standardization steps are to prepare the state code to be normalized and joined with other states. As part of this there is a specific naming pattern for columns. Standard table attributes are named in table.yaml under attributes. Provided source data, however, may not be normalized. These columns will be named with a SPLIT separator ('--') between the name of the relation and the name of the attribute in the related column. This may be nested (i.e. if in a transaction table we are given a donor's address, this would be shown as 'donor--address--line_1'). If a column is a repeated column (i.e. there are two amount columns to signify two transactions that share all other properties), it will end with '-\d' where \d is an integer. Valid column names include alphabetic characters and underscores.
 
+#### Year Filtering Configuration
+
+To enable year filtering for data sources, add the following optional fields:
+
+- `year_filter_filepath_regex`: (optional) Regex pattern to extract year from file paths. The first capture group should contain the year as a 4-digit number (e.g., `"^(\\d{4})/"`).
+- `year_column`: (optional) Raw column name containing year data for row-level filtering.
+
+When both are provided, filepath filtering is applied first to reduce the number of files read, then column filtering is applied to the resulting data.
+
+Example:
+```yaml
+contributions_2020_2022:
+  inherits: base
+  path_pattern: "(?i)^(20[2-3][0-9])/contrib.*\\.txt$"
+  year_filter_filepath_regex: "^(\\d{4})/"  # Extract year from path like "2021/contrib.txt"
+  year_column: "ELECTION_YEAR"  # Filter rows by this column after reading
+```
+
+This configuration allows the `standardize_states` function to filter data by year using `start_year` and `end_year` parameters.
+
 ### Walkthrough: Pennsylvania
 
 Here we go through an example of adding a new state to the campaign finance pipeline.

--- a/output/README.md
+++ b/output/README.md
@@ -1,5 +1,0 @@
-# Output README
----
-'deduplicated_UUIDs.csv' : Following record linkage work in the record_linkage pipeline, this file stores all the original uuids, and indicates the uuids to which the deduplicated uuids have been matched to.
-
-'network_metrics.txt' : Following the network graph creation, this file stores some summarizing metrics about the netowork including: 50 nodes of highest centrality (in-degree, out-degree, eigenvector, and betweenness), density, assortativity based on classification, and clustering.

--- a/scripts/normalize_pipeline.py
+++ b/scripts/normalize_pipeline.py
@@ -12,13 +12,13 @@ parser.add_argument(
     "-i",
     "--input-directory",
     default=None,
-    help="Path to standardized input data. Default is 'output/standardized' in repo root",
+    help="Path to standardized input data. Default is 'data/standardized' in repo root",
 )
 parser.add_argument(
     "-o",
     "--output-directory",
     default=None,
-    help="Path to directory to save output. Default is 'output/normalized'",
+    help="Path to directory to save data. Default is 'data/normalized'",
 )
 parser.add_argument(
     "-s",
@@ -29,11 +29,11 @@ parser.add_argument(
 args = parser.parse_args()
 
 if args.output_directory is None:
-    output_directory = BASE_FILEPATH / "output" / "normalized"
+    output_directory = BASE_FILEPATH / "data" / "normalized"
 else:
     output_directory = args.output_directory
 if args.input_directory is None:
-    input_directory = BASE_FILEPATH / "output" / "standardized"
+    input_directory = BASE_FILEPATH / "data" / "standardized"
 else:
     input_directory = args.input_directory
 input_directory.mkdir(parents=True, exist_ok=True)

--- a/scripts/normalize_pipeline.py
+++ b/scripts/normalize_pipeline.py
@@ -3,7 +3,7 @@
 import argparse
 
 from utils.constants import BASE_FILEPATH
-from utils.io import load_database_from_csv, save_database_to_csv
+from utils.io import load_database, save_database
 from utils.normalize import Normalizer
 
 parser = argparse.ArgumentParser()
@@ -26,6 +26,18 @@ parser.add_argument(
     default=None,
     help="Path to data schema, defaulting to src/utils/table.yaml",
 )
+parser.add_argument(
+    "--input-format",
+    choices=["csv", "parquet"],
+    default="csv",
+    help="Input file format (csv or parquet). Default is csv",
+)
+parser.add_argument(
+    "--output-format",
+    choices=["csv", "parquet"],
+    default="csv",
+    help="Output file format (csv or parquet). Default is csv",
+)
 args = parser.parse_args()
 
 if args.output_directory is None:
@@ -43,7 +55,7 @@ if args.schema is None:
 else:
     schema_path = args.schema
 
-standardized_database = load_database_from_csv(input_directory)
+standardized_database = load_database(input_directory, format=args.input_format)
 normalizer = Normalizer(standardized_database, schema_path)
 normalized_database = normalizer.normalize_database()
-save_database_to_csv(normalized_database, output_directory)
+save_database(normalized_database, output_directory, format=args.output_format)

--- a/scripts/normalize_pipeline.py
+++ b/scripts/normalize_pipeline.py
@@ -66,7 +66,7 @@ else:
     schema_path = args.schema
 
 # Set up ID mapping file path
-id_mapping_file = output_directory / "id_mapping.json"
+id_mapping_file = output_directory / "id_mapping.tsv"
 
 # Process database in chunks or all at once
 if args.chunk_size is None:

--- a/scripts/standardize_pipeline.py
+++ b/scripts/standardize_pipeline.py
@@ -18,12 +18,12 @@ parser.add_argument(
     "-o",
     "--output-directory",
     default=None,
-    help="Path to directory to save output. Default is 'output/standardized'",
+    help="Path to directory to save data. Default is 'data/standardized'",
 )
 args = parser.parse_args()
 
 if args.output_directory is None:
-    output_directory = BASE_FILEPATH / "output" / "standardized"
+    output_directory = BASE_FILEPATH / "data" / "standardized"
 else:
     output_directory = args.output_directory
 states = args.states

--- a/scripts/standardize_pipeline.py
+++ b/scripts/standardize_pipeline.py
@@ -39,6 +39,12 @@ parser.add_argument(
     default="csv",
     help="Output file format (csv or parquet). Default is csv",
 )
+parser.add_argument(
+    "-d",
+    "--data-directory",
+    default=None,
+    help="Path to directory containing raw data. Default is 'data/raw'",
+)
 args = parser.parse_args()
 
 if args.output_directory is None:
@@ -49,6 +55,9 @@ states = args.states
 output_directory.mkdir(parents=True, exist_ok=True)
 
 database = standardize_states(
-    states=states, start_year=args.start_year, end_year=args.end_year
+    states=states,
+    start_year=args.start_year,
+    end_year=args.end_year,
+    data_directory=args.data_directory,
 )
 save_database(database, output_directory, format=args.format)

--- a/scripts/standardize_pipeline.py
+++ b/scripts/standardize_pipeline.py
@@ -4,7 +4,7 @@ import argparse
 
 from utils.constants import BASE_FILEPATH
 from utils.finance.pipeline import standardize_states
-from utils.io import save_database_to_csv
+from utils.io import save_database
 
 parser = argparse.ArgumentParser()
 
@@ -32,6 +32,13 @@ parser.add_argument(
     default=None,
     help="Path to directory to save data. Default is 'data/standardized'",
 )
+parser.add_argument(
+    "-f",
+    "--format",
+    choices=["csv", "parquet"],
+    default="csv",
+    help="Output file format (csv or parquet). Default is csv",
+)
 args = parser.parse_args()
 
 if args.output_directory is None:
@@ -44,4 +51,4 @@ output_directory.mkdir(parents=True, exist_ok=True)
 database = standardize_states(
     states=states, start_year=args.start_year, end_year=args.end_year
 )
-save_database_to_csv(database, output_directory)
+save_database(database, output_directory, format=args.format)

--- a/scripts/standardize_pipeline.py
+++ b/scripts/standardize_pipeline.py
@@ -15,6 +15,18 @@ parser.add_argument(
     help="State abbreviations of all states to run pipeline on",
 )
 parser.add_argument(
+    "--start_year",
+    type=int,
+    default=None,
+    help="Start year of elections to run pipeline on",
+)
+parser.add_argument(
+    "--end_year",
+    type=int,
+    default=None,
+    help="End year of elections to run pipeline on",
+)
+parser.add_argument(
     "-o",
     "--output-directory",
     default=None,
@@ -29,5 +41,7 @@ else:
 states = args.states
 output_directory.mkdir(parents=True, exist_ok=True)
 
-database = standardize_states(states=states)
+database = standardize_states(
+    states=states, start_year=args.start_year, end_year=args.end_year
+)
 save_database_to_csv(database, output_directory)

--- a/src/utils/config/finance/states/pa.yaml
+++ b/src/utils/config/finance/states/pa.yaml
@@ -6,6 +6,7 @@ base:
     on_bad_lines: warn
   state_code_columns:
     - reported_state
+  year_filter_filepath_regex: ".*\\/(\\d{4})\\/[^\\/]+$"
 
 
 contributions:

--- a/src/utils/finance/config.py
+++ b/src/utils/finance/config.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from yaml import safe_load
 
-from utils.constants import BASE_FILEPATH, RAW_DATA_DIRECTORY
+from utils.constants import BASE_FILEPATH
 
 
 def resolve_inheritance(config: dict, form_code: str) -> dict:
@@ -59,20 +59,6 @@ class ConfigHandler:
     def raw_data_path_pattern(self) -> str:
         """Regex matching names of raw files in data/raw folder"""
         return re.compile(self._raw_data_path_pattern)
-
-    @property
-    def raw_data_file_paths(self) -> list[Path]:
-        """All files matching raw data pattern at compile time"""
-        state_data_directory = RAW_DATA_DIRECTORY / self.state_code
-        matching_files = [
-            path
-            for path in state_data_directory.rglob("*")
-            if path.is_file()
-            and self.raw_data_path_pattern.fullmatch(
-                str(path.relative_to(state_data_directory)).replace("\\", "/")
-            )
-        ]
-        return matching_files
 
     @property
     def dtype_dict(self) -> dict[str, str]:

--- a/src/utils/finance/config.py
+++ b/src/utils/finance/config.py
@@ -136,6 +136,16 @@ class ConfigHandler:
         """List of columns in order in raw file"""
         return self._raw_colum_order
 
+    @property
+    def year_filter_filepath_regex(self) -> str | None:
+        """Regex pattern to extract year from filepath for filtering"""
+        return self._year_filter_filepath_regex
+
+    @property
+    def year_column(self) -> str | None:
+        """Raw column name containing year data for filtering"""
+        return self._year_column
+
     def __init__(
         self,
         form_code: str,
@@ -195,3 +205,5 @@ class ConfigHandler:
         self._state_code = form_config.get("state_code", state_code)
         self._table_name = form_config.get("table_name")
         self._raw_data_path_pattern = form_config.get("path_pattern")
+        self._year_filter_filepath_regex = form_config.get("year_filter_filepath_regex")
+        self._year_column = form_config.get("year_column")

--- a/src/utils/finance/pipeline.py
+++ b/src/utils/finance/pipeline.py
@@ -11,13 +11,17 @@ ALL_STATE_SOURCES = get_registered_sources()
 
 
 def standardize_states(
-    states: list[str] = None,
+    states: list[str] = None, start_year: int = None, end_year: int = None
 ) -> dict[str, pd.DataFrame]:
     """From raw datafiles, standardize data from specified states.
 
     Args:
         states: List of states to merge data from. If None,
             will default to all states that have been implemented
+        start_year: Year to start filtering data from. If None,
+            will default to the earliest year in the data
+        end_year: Year to end filtering data at. If None,
+            will default to the latest year in the data
 
     Returns:
         dictionary mapping table name to tables of that type
@@ -29,7 +33,9 @@ def standardize_states(
     database = {}
     for state in states:
         for source in ALL_STATE_SOURCES[state]:
-            standardized_source_table = source.load_and_standardize_data_source()
+            standardized_source_table = source.load_and_standardize_data_source(
+                start_year=start_year, end_year=end_year
+            )
             if source.table_name not in database:
                 database[source.table_name] = pd.DataFrame()
 

--- a/src/utils/finance/pipeline.py
+++ b/src/utils/finance/pipeline.py
@@ -1,5 +1,7 @@
 """Merge raw state campaign finance into standardized schema"""
 
+from pathlib import Path
+
 import pandas as pd
 
 from utils.finance.data_source_registry import (
@@ -11,7 +13,10 @@ ALL_STATE_SOURCES = get_registered_sources()
 
 
 def standardize_states(
-    states: list[str] = None, start_year: int = None, end_year: int = None
+    states: list[str] = None,
+    start_year: int = None,
+    end_year: int = None,
+    data_directory: Path | None = None,
 ) -> dict[str, pd.DataFrame]:
     """From raw datafiles, standardize data from specified states.
 
@@ -22,6 +27,8 @@ def standardize_states(
             will default to the earliest year in the data
         end_year: Year to end filtering data at. If None,
             will default to the latest year in the data
+        data_directory: Path to directory containing raw data. If None,
+            will default to 'data/raw'
 
     Returns:
         dictionary mapping table name to tables of that type
@@ -34,7 +41,9 @@ def standardize_states(
     for state in states:
         for source in ALL_STATE_SOURCES[state]:
             standardized_source_table = source.load_and_standardize_data_source(
-                start_year=start_year, end_year=end_year
+                start_year=start_year,
+                end_year=end_year,
+                state_data_directory=data_directory,
             )
             if source.table_name not in database:
                 database[source.table_name] = pd.DataFrame()

--- a/src/utils/io.py
+++ b/src/utils/io.py
@@ -1,55 +1,229 @@
-"""Module handling file input/output"""
+"""Database I/O utilities for CSV and Parquet formats."""
 
+from collections.abc import Generator
 from pathlib import Path
 from typing import Literal
 
 import pandas as pd
+import pyarrow.parquet as pq
 
 FileFormat = Literal["csv", "parquet"]
 
 
+def load_database(
+    path: Path,
+    format: FileFormat = "csv",
+    chunk_size: int | None = None,
+) -> dict[str, pd.DataFrame] | Generator[dict[str, pd.DataFrame], None, None]:
+    """Load database from directory containing table files.
+
+    Args:
+        path: Directory containing data files
+        format: File format to read ('csv' or 'parquet')
+        chunk_size: If specified, returns chunked generator for memory efficiency
+
+    Returns:
+        Dictionary of table_name -> DataFrame, or generator yielding chunks
+    """
+    if chunk_size is None:
+        return _load_database_full(path, format)
+    return _load_database_chunked(path, format, chunk_size)
+
+
 def save_database(
-    database: dict[str, pd.DataFrame], output_path: Path, format: FileFormat = "csv"
+    database: dict[str, pd.DataFrame],
+    path: Path,
+    format: FileFormat = "csv",
+    mode: Literal["overwrite", "append"] = "overwrite",
 ) -> None:
-    """Save each table in database with specified format.
+    """Save database to directory with one file per table.
 
     Args:
         database: Dictionary mapping table names to DataFrames
-        output_path: Directory path to store database files
+        path: Directory to save files
         format: File format to use ('csv' or 'parquet')
+        mode: Whether to overwrite existing files or append
     """
-    for table_name, table in database.items():
-        file_path = output_path / f"{table_name}.{format}"
+    path.mkdir(parents=True, exist_ok=True)
 
-        if format == "csv":
-            save_index = bool(table.index.name)
-            table.to_csv(file_path, index=save_index)
-        elif format == "parquet":
-            table.to_parquet(file_path, index=bool(table.index.name))
+    for table_name, df in database.items():
+        file_path = path / f"{table_name}.{format}"
+        _save_table(df, file_path, format, mode)
 
 
-def load_database(
-    input_path: Path, format: FileFormat = "csv"
-) -> dict[str, pd.DataFrame]:
-    """Load database from directory containing files of specified format.
+def load_table_chunked(
+    file_path: Path,
+    chunk_size: int,
+    format: FileFormat = "csv",
+) -> Generator[pd.DataFrame, None, None]:
+    """Load single table in memory-efficient chunks.
 
     Args:
-        input_path: Directory path containing data files
-        format: File format to read ('csv' or 'parquet')
+        file_path: Path to data file
+        chunk_size: Number of rows per chunk
+        format: File format to read
 
-    Returns:
-        Dictionary mapping table names to DataFrames
+    Yields:
+        DataFrame chunks
     """
+    if format == "csv":
+        yield from pd.read_csv(file_path, chunksize=chunk_size)
+    elif format == "parquet":
+        total_rows = _count_rows(file_path)
+        for start in range(0, total_rows, chunk_size):
+            end = min(start + chunk_size, total_rows)
+            yield _read_parquet_chunk(file_path, start, end)
+
+
+# Private utility functions
+
+
+def _load_database_full(path: Path, format: FileFormat) -> dict[str, pd.DataFrame]:
+    """Load entire database into memory."""
     database = {}
-    file_extension = f".{format}"
 
-    for file_path in input_path.iterdir():
-        if file_path.suffix == file_extension:
-            table_name = file_path.stem
-
-            if format == "csv":
-                database[table_name] = pd.read_csv(file_path)
-            elif format == "parquet":
-                database[table_name] = pd.read_parquet(file_path)
+    for file_path in _get_data_files(path, format):
+        table_name = file_path.stem
+        database[table_name] = _load_table(file_path, format)
 
     return database
+
+
+def _load_database_chunked(
+    path: Path, format: FileFormat, chunk_size: int
+) -> Generator[dict[str, pd.DataFrame], None, None]:
+    """Load database in chunks across all tables simultaneously."""
+    table_files = {f.stem: f for f in _get_data_files(path, format)}
+    table_positions = {name: 0 for name in table_files}
+    table_totals = {
+        name: _count_rows(file_path) for name, file_path in table_files.items()
+    }
+
+    while any(pos < table_totals[name] for name, pos in table_positions.items()):
+        chunk_db = {}
+
+        for table_name, file_path in table_files.items():
+            start = table_positions[table_name]
+            if start >= table_totals[table_name]:
+                continue
+
+            end = min(start + chunk_size, table_totals[table_name])
+            chunk_db[table_name] = _read_chunk(file_path, start, end, format)
+            table_positions[table_name] = end
+
+        if chunk_db:
+            yield chunk_db
+
+
+def _get_data_files(path: Path, format: FileFormat) -> list[Path]:
+    """Get all data files with the specified format."""
+    return [f for f in path.iterdir() if f.suffix == f".{format}"]
+
+
+def _load_table(file_path: Path, format: FileFormat) -> pd.DataFrame:
+    """Load a single table file."""
+    if format == "csv":
+        return pd.read_csv(file_path)
+    elif format == "parquet":
+        return pd.read_parquet(file_path)
+
+
+def _save_table(
+    df: pd.DataFrame,
+    file_path: Path,
+    format: FileFormat,
+    mode: Literal["overwrite", "append"],
+) -> None:
+    """Save a single table file."""
+    save_index = bool(df.index.name)
+
+    if format == "csv":
+        write_header = mode == "overwrite" or not file_path.exists()
+        write_mode = "w" if mode == "overwrite" else "a"
+        df.to_csv(file_path, index=save_index, header=write_header, mode=write_mode)
+
+    elif format == "parquet":
+        if mode == "append" and file_path.exists():
+            existing_df = pd.read_parquet(file_path)
+            combined_df = pd.concat([existing_df, df], ignore_index=True)
+            combined_df.to_parquet(file_path, index=save_index)
+        else:
+            df.to_parquet(file_path, index=save_index)
+
+
+def _count_rows(file_path: Path) -> int:
+    """Count rows in a data file."""
+    if file_path.suffix == ".csv":
+        return sum(1 for _ in file_path.open()) - 1  # Exclude header
+    elif file_path.suffix == ".parquet":
+        return pq.read_metadata(file_path).num_rows
+
+
+def _read_chunk(
+    file_path: Path, start_row: int, end_row: int, format: FileFormat
+) -> pd.DataFrame:
+    """Read a specific chunk from a file."""
+    if format == "csv":
+        return pd.read_csv(
+            file_path, skiprows=range(1, start_row + 1), nrows=end_row - start_row
+        )
+    elif format == "parquet":
+        return _read_parquet_chunk(file_path, start_row, end_row)
+
+
+def _read_parquet_chunk(file_path: Path, start_row: int, end_row: int) -> pd.DataFrame:
+    """Read a chunk from a parquet file using row groups for efficiency."""
+    parquet_file = pq.ParquetFile(file_path)
+
+    # Find which row groups contain the requested rows
+    row_groups_to_read = []
+    current_row = 0
+
+    for i in range(parquet_file.num_row_groups):
+        row_group_metadata = parquet_file.metadata.row_group(i)
+        row_group_size = row_group_metadata.num_rows
+        row_group_end = current_row + row_group_size
+
+        # Check if this row group overlaps with our target range
+        if current_row < end_row and row_group_end > start_row:
+            row_groups_to_read.append(i)
+
+        current_row = row_group_end
+
+        # Stop if we've passed our target range
+        if current_row >= end_row:
+            break
+
+    # Read only the necessary row groups
+    if not row_groups_to_read:
+        # Return empty DataFrame with correct schema
+        schema_table = parquet_file.read_row_group(0, columns=None).slice(0, 0)
+        return schema_table.to_pandas()
+
+    # Read the selected row groups
+    tables = []
+    for row_group_idx in row_groups_to_read:
+        table = parquet_file.read_row_group(row_group_idx)
+        tables.append(table)
+
+    # Concatenate row groups if multiple were read
+    if len(tables) == 1:
+        combined_table = tables[0]
+    else:
+        import pyarrow as pa
+
+        combined_table = pa.concat_tables(tables)
+
+    # Convert to pandas and slice to exact range
+    pandas_df = combined_table.to_pandas()
+
+    # Calculate the offset within our read data
+    first_row_group_start = 0
+    for i in range(row_groups_to_read[0]):
+        first_row_group_start += parquet_file.metadata.row_group(i).num_rows
+
+    # Adjust indices relative to the data we actually read
+    local_start = max(0, start_row - first_row_group_start)
+    local_end = min(len(pandas_df), end_row - first_row_group_start)
+
+    return pandas_df.iloc[local_start:local_end]

--- a/src/utils/io.py
+++ b/src/utils/io.py
@@ -73,6 +73,8 @@ def load_table_chunked(
         for start in range(0, total_rows, chunk_size):
             end = min(start + chunk_size, total_rows)
             yield _read_parquet_chunk(file_path, start, end)
+    else:
+        raise ValueError(f"Invalid format: {format}")
 
 
 # Private utility functions
@@ -144,6 +146,7 @@ def _save_table(
 
     elif format == "parquet":
         if mode == "append" and file_path.exists():
+            # TODO: this reads the entire file into memory. There should be a better way
             existing_df = pd.read_parquet(file_path)
             combined_df = pd.concat([existing_df, df], ignore_index=True)
             combined_df.to_parquet(file_path, index=save_index)

--- a/src/utils/io.py
+++ b/src/utils/io.py
@@ -1,34 +1,55 @@
 """Module handling file input/output"""
 
 from pathlib import Path
+from typing import Literal
 
 import pandas as pd
 
+FileFormat = Literal["csv", "parquet"]
 
-def save_database_to_csv(database: dict[str, pd.DataFrame], output_path: Path) -> None:
-    """Save each value in database as a csv with name key.csv
+
+def save_database(
+    database: dict[str, pd.DataFrame], output_path: Path, format: FileFormat = "csv"
+) -> None:
+    """Save each table in database with specified format.
 
     Args:
-        database: TODO
-        output_path: path to directory to store database in
+        database: Dictionary mapping table names to DataFrames
+        output_path: Directory path to store database files
+        format: File format to use ('csv' or 'parquet')
     """
     for table_name, table in database.items():
-        if table.index.name:
-            save_index = True
-        else:
-            save_index = False
-        table.to_csv(output_path / f"{table_name}.csv", index=save_index)
+        file_path = output_path / f"{table_name}.{format}"
+
+        if format == "csv":
+            save_index = bool(table.index.name)
+            table.to_csv(file_path, index=save_index)
+        elif format == "parquet":
+            table.to_parquet(file_path, index=bool(table.index.name))
 
 
-def load_database_from_csv(input_path: Path) -> dict[str, pd.DataFrame]:
-    """Load a database from a directory containing csv file for each table name
+def load_database(
+    input_path: Path, format: FileFormat = "csv"
+) -> dict[str, pd.DataFrame]:
+    """Load database from directory containing files of specified format.
 
     Args:
-        input_path: path to directory with csv files
+        input_path: Directory path containing data files
+        format: File format to read ('csv' or 'parquet')
+
+    Returns:
+        Dictionary mapping table names to DataFrames
     """
     database = {}
-    for file in input_path.iterdir():
-        database[file.stem] = pd.read_csv(
-            file,
-        )
+    file_extension = f".{format}"
+
+    for file_path in input_path.iterdir():
+        if file_path.suffix == file_extension:
+            table_name = file_path.stem
+
+            if format == "csv":
+                database[table_name] = pd.read_csv(file_path)
+            elif format == "parquet":
+                database[table_name] = pd.read_parquet(file_path)
+
     return database

--- a/src/utils/normalize.py
+++ b/src/utils/normalize.py
@@ -49,13 +49,17 @@ class Normalizer:
         return self._id_mapping
 
     def __init__(
-        self, database: dict[str, pd.DataFrame], schema: DataSchema | Path | str
+        self,
+        database: dict[str, pd.DataFrame],
+        schema: DataSchema | Path | str,
+        existing_id_mapping: dict[tuple, str] | None = None,
     ) -> None:
         """Create new normalizer
 
         Args:
-            database: TODO
+            database: Dictionary of table names to DataFrames
             schema: DataSchema object or path to yaml file containing one
+            existing_id_mapping: Pre-existing ID mappings to maintain consistency across chunks
         """
         self.database = database
         if isinstance(schema, str | Path):
@@ -63,7 +67,7 @@ class Normalizer:
         elif not isinstance(schema, DataSchema):
             raise RuntimeError("schema must be path or DataSchema object")
         self.schema = schema
-        self._id_mapping = {}
+        self._id_mapping = existing_id_mapping.copy() if existing_id_mapping else {}
 
     def get_foreign_table_name(self, base_type: str, column_name: str) -> str:
         """Retrieve the type of a multivalued/foreign table"""

--- a/tests/test_config_handler.py
+++ b/tests/test_config_handler.py
@@ -197,23 +197,6 @@ def test_raw_data_path_pattern(sample_config):
     assert not handler.raw_data_path_pattern.fullmatch("2018/noncontrib.csv")
 
 
-def test_raw_data_file_paths(sample_config, mock_raw_data_directory):
-    state_data_directory = mock_raw_data_directory / "NY"
-    state_data_directory.mkdir()
-    valid_file = state_data_directory / "2021/contrib_test.txt"
-    invalid_file = state_data_directory / "2018/noncontrib.csv"
-    valid_file.parent.mkdir(parents=True, exist_ok=True)
-    invalid_file.parent.mkdir(parents=True, exist_ok=True)
-    valid_file.touch()
-    invalid_file.touch()
-
-    handler = ConfigHandler("contributions", config_file_path=sample_config)
-
-    matching_files = handler.raw_data_file_paths
-    assert valid_file in matching_files
-    assert invalid_file not in matching_files
-
-
 @pytest.fixture
 def inheritance_config(tmp_path):
     config_data = {

--- a/tests/test_data_source_standardization_pipeline.py
+++ b/tests/test_data_source_standardization_pipeline.py
@@ -311,7 +311,6 @@ def mock_pipeline(
 
     # Mock DataReader
     mock_data_reader = MagicMock()
-    mock_data_reader.default_raw_data_paths = mock_config_handler.raw_data_file_paths
     mock_data_reader.read_tabular_data.return_value = raw_data
 
     # Mock SchemaTransformer
@@ -334,7 +333,9 @@ def mock_pipeline(
         pipeline.data_reader = mock_data_reader
         pipeline.schema_transformer = mock_schema_transformer
         pipeline.data_standardizer = mock_data_standardizer
-
+        pipeline._raw_data_file_paths = MagicMock(
+            return_value=[Path("contributions.csv")]
+        )
     return pipeline
 
 

--- a/tests/test_data_source_standardization_pipeline.py
+++ b/tests/test_data_source_standardization_pipeline.py
@@ -28,6 +28,15 @@ def mock_config_handler():
     }
     mock.read_csv_params = {"sep": ","}
     mock.raw_data_file_paths = [Path("contributions.csv")]
+    mock.raw_column_order = [
+        "DONOR",
+        "RECIPID",
+        "TRANSDATE",
+        "DONORCOMPNAME",
+        "amount",
+        "EOFFICE",
+        "USELESS",
+    ]
     mock.column_mapper = {
         "DONOR": "donor--name",
         "RECIPID": "recipient_id",
@@ -51,6 +60,8 @@ def mock_config_handler():
         }
     }
     mock.column_to_date_format = {"date": "%m/%d/%Y"}
+    mock.year_filter_filepath_regex = None
+    mock.year_column = None
     return mock
 
 
@@ -134,6 +145,42 @@ def standardized_data():
     )
 
 
+@pytest.fixture
+def mock_config_handler_with_year_filter():
+    """Creates a mock configuration handler with year filtering enabled."""
+    mock = MagicMock(spec=ConfigHandler)
+    mock.dtype_dict = {
+        "DONOR": "str",
+        "EYEAR": "Int32",
+        "TRANSDATE": "str",
+        "amount": "Float32",
+    }
+    mock.read_csv_params = {"sep": ","}
+    mock.raw_data_file_paths = [
+        Path("2020/contributions.csv"),
+        Path("2021/contributions.csv"),
+        Path("2022/contributions.csv"),
+        Path("2023/contributions.csv"),
+    ]
+    mock.raw_column_order = ["DONOR", "EYEAR", "TRANSDATE", "amount"]
+    mock.year_filter_filepath_regex = "^(\\d{4})/"
+    mock.year_column = "EYEAR"
+    return mock
+
+
+@pytest.fixture
+def year_filtered_data():
+    """Sample data with year column"""
+    return pd.DataFrame(
+        {
+            "DONOR": ["person 1", "person 2", "person 3", "person 4"],
+            "EYEAR": [2020, 2021, 2022, 2023],
+            "TRANSDATE": ["1/20/2020", "12/31/2021", "3/4/2022", "6/15/2023"],
+            "amount": [120.34, 1200, 3400.23, 500.00],
+        }
+    )
+
+
 # ---- UNIT TESTS ----
 class TestDataReader:
     """Tests for DataReader class."""
@@ -144,13 +191,13 @@ class TestDataReader:
         mock_read_csv.return_value = pd.DataFrame(raw_data)
         reader = DataReader(mock_config_handler)
 
-        raw_data = reader.read_tabular_data()
+        result = reader.read_tabular_data(Path("contributions.csv"))
 
         mock_read_csv.assert_called_once_with(
             "contributions.csv", dtype=mock_config_handler.dtype_dict, sep=","
         )
-        assert not raw_data.empty
-        assert list(raw_data.columns) == [
+        assert not result.empty
+        assert list(result.columns) == [
             "DONOR",
             "RECIPID",
             "TRANSDATE",
@@ -164,7 +211,24 @@ class TestDataReader:
         """Ensure an error is raised if the file is missing."""
         reader = DataReader(mock_config_handler)
         with pytest.raises(FileNotFoundError):
-            reader.read_tabular_data("non_existent_file.csv")
+            reader.read_tabular_data(Path("non_existent_file.csv"))
+
+    @patch("pandas.read_csv")
+    def test_read_tabular_data_with_year_filtering(
+        self, mock_read_csv, mock_config_handler, raw_data
+    ):
+        """Test read_tabular_data with year filtering parameters"""
+        mock_read_csv.return_value = raw_data
+        reader = DataReader(mock_config_handler)
+
+        result = reader.read_tabular_data(
+            Path("contributions.csv"), start_year=2020, end_year=2022
+        )
+
+        mock_read_csv.assert_called_once_with(
+            "contributions.csv", dtype=mock_config_handler.dtype_dict, sep=","
+        )
+        assert not result.empty
 
 
 class TestSchemaTransformer:
@@ -283,9 +347,187 @@ def test_load_standardize_data_source(mock_pipeline, standardized_data):
     # Validate the output
     pd.testing.assert_frame_equal(result_df, standardized_data)
 
-    # Ensure each step was called once
+    # Ensure each step was called once with the correct arguments
     mock_pipeline.data_reader.read_tabular_data.assert_called_once_with(
-        Path("contributions.csv")
+        Path("contributions.csv"), None, None
     )
     mock_pipeline.schema_transformer.standardize_schema.assert_called_once()
     mock_pipeline.data_standardizer.standardize_data.assert_called_once()
+
+
+class TestDataReaderYearFiltering:
+    """Tests for DataReader year filtering functionality."""
+
+    def test_filter_year_by_filepath(self, mock_config_handler_with_year_filter):
+        """Test filtering file paths by year"""
+        reader = DataReader(mock_config_handler_with_year_filter)
+
+        # Test filtering for years 2021-2022
+        assert reader._filter_year_by_filepath(
+            Path("2021/contributions.csv"), 2021, 2022
+        )
+        assert reader._filter_year_by_filepath(
+            Path("2022/contributions.csv"), 2021, 2022
+        )
+        assert not reader._filter_year_by_filepath(
+            Path("2020/contributions.csv"), 2021, 2022
+        )
+        assert not reader._filter_year_by_filepath(
+            Path("2023/contributions.csv"), 2021, 2022
+        )
+
+    def test_filter_year_by_filepath_start_year_only(
+        self, mock_config_handler_with_year_filter
+    ):
+        """Test filtering with only start year"""
+        reader = DataReader(mock_config_handler_with_year_filter)
+
+        assert reader._filter_year_by_filepath(
+            Path("2022/contributions.csv"), 2022, None
+        )
+        assert reader._filter_year_by_filepath(
+            Path("2023/contributions.csv"), 2022, None
+        )
+        assert not reader._filter_year_by_filepath(
+            Path("2021/contributions.csv"), 2022, None
+        )
+
+    def test_filter_year_by_filepath_end_year_only(
+        self, mock_config_handler_with_year_filter
+    ):
+        """Test filtering with only end year"""
+        reader = DataReader(mock_config_handler_with_year_filter)
+
+        assert reader._filter_year_by_filepath(
+            Path("2020/contributions.csv"), None, 2021
+        )
+        assert reader._filter_year_by_filepath(
+            Path("2021/contributions.csv"), None, 2021
+        )
+        assert not reader._filter_year_by_filepath(
+            Path("2022/contributions.csv"), None, 2021
+        )
+
+    def test_filter_year_by_filepath_no_regex(self):
+        """Test that filtering returns True when no regex is configured"""
+        mock_handler = MagicMock()
+        mock_handler.year_filter_filepath_regex = None
+        mock_handler.year_column = None
+        mock_handler.dtype_dict = {}
+        mock_handler.read_csv_params = {}
+        mock_handler.raw_column_order = []
+
+        reader = DataReader(mock_handler)
+
+        assert reader._filter_year_by_filepath(Path("file1.csv"), 2021, 2022) is True
+        assert reader._filter_year_by_filepath(Path("file2.csv"), 2021, 2022) is True
+
+    def test_filter_year_by_column(
+        self, mock_config_handler_with_year_filter, year_filtered_data
+    ):
+        """Test filtering dataframe by year column"""
+        reader = DataReader(mock_config_handler_with_year_filter)
+
+        # Test filtering for years 2021-2022
+        filtered_data = reader._filter_year_by_column(year_filtered_data, 2021, 2022)
+        expected_years = [2021, 2022]
+        assert list(filtered_data["EYEAR"]) == expected_years
+
+    def test_filter_year_by_column_start_year_only(
+        self, mock_config_handler_with_year_filter, year_filtered_data
+    ):
+        """Test filtering with only start year"""
+        reader = DataReader(mock_config_handler_with_year_filter)
+
+        filtered_data = reader._filter_year_by_column(year_filtered_data, 2022, None)
+        expected_years = [2022, 2023]
+        assert list(filtered_data["EYEAR"]) == expected_years
+
+    def test_filter_year_by_column_end_year_only(
+        self, mock_config_handler_with_year_filter, year_filtered_data
+    ):
+        """Test filtering with only end year"""
+        reader = DataReader(mock_config_handler_with_year_filter)
+
+        filtered_data = reader._filter_year_by_column(year_filtered_data, None, 2021)
+        expected_years = [2020, 2021]
+        assert list(filtered_data["EYEAR"]) == expected_years
+
+    def test_filter_year_by_column_no_year_column(self, year_filtered_data):
+        """Test that filtering returns original data when no year column is configured"""
+        mock_handler = MagicMock()
+        mock_handler.year_filter_filepath_regex = None
+        mock_handler.year_column = None
+        mock_handler.dtype_dict = {}
+        mock_handler.read_csv_params = {}
+        mock_handler.raw_column_order = []
+
+        reader = DataReader(mock_handler)
+
+        filtered_data = reader._filter_year_by_column(year_filtered_data, 2021, 2022)
+        pd.testing.assert_frame_equal(filtered_data, year_filtered_data)
+
+    def test_filter_year_by_column_missing_column(
+        self, mock_config_handler_with_year_filter
+    ):
+        """Test that filtering returns original data when year column is missing from data"""
+        reader = DataReader(mock_config_handler_with_year_filter)
+        data_without_year = pd.DataFrame(
+            {
+                "DONOR": ["person 1", "person 2"],
+                "amount": [120.34, 1200],
+            }
+        )
+
+        filtered_data = reader._filter_year_by_column(data_without_year, 2021, 2022)
+        pd.testing.assert_frame_equal(filtered_data, data_without_year)
+
+    @patch("pandas.read_csv")
+    def test_read_tabular_data_with_year_filtering_single_file(
+        self, mock_read_csv, mock_config_handler_with_year_filter, year_filtered_data
+    ):
+        """Test read_tabular_data with year filtering on a single file"""
+        mock_read_csv.return_value = year_filtered_data
+        reader = DataReader(mock_config_handler_with_year_filter)
+
+        # Test reading a file that passes the year filter
+        result = reader.read_tabular_data(
+            Path("2021/contributions.csv"), start_year=2021, end_year=2022
+        )
+
+        mock_read_csv.assert_called_once_with(
+            "2021/contributions.csv",
+            dtype=mock_config_handler_with_year_filter.dtype_dict,
+            sep=",",
+        )
+        # Should contain years 2021-2022 due to column filtering
+        assert list(result["EYEAR"]) == [2021, 2022]
+
+    @patch("pandas.read_csv")
+    def test_read_tabular_data_filtered_out_by_filepath(
+        self, mock_read_csv, mock_config_handler_with_year_filter
+    ):
+        """Test that read_tabular_data returns empty DataFrame when file is filtered out by filepath"""
+        reader = DataReader(mock_config_handler_with_year_filter)
+
+        # Try to read a file that doesn't match the year filter
+        result = reader.read_tabular_data(
+            Path("2020/contributions.csv"), start_year=2021, end_year=2022
+        )
+
+        # Should not call read_csv since file is filtered out
+        mock_read_csv.assert_not_called()
+        assert result.empty
+
+    @patch("pandas.read_csv")
+    def test_read_tabular_data_no_year_filtering(
+        self, mock_read_csv, mock_config_handler_with_year_filter, year_filtered_data
+    ):
+        """Test read_tabular_data without year filtering"""
+        mock_read_csv.return_value = year_filtered_data
+        reader = DataReader(mock_config_handler_with_year_filter)
+
+        result = reader.read_tabular_data(Path("2021/contributions.csv"))
+
+        mock_read_csv.assert_called_once()
+        pd.testing.assert_frame_equal(result, year_filtered_data)

--- a/tests/test_data_source_standardization_pipeline.py
+++ b/tests/test_data_source_standardization_pipeline.py
@@ -364,16 +364,16 @@ class TestDataReaderYearFiltering:
         reader = DataReader(mock_config_handler_with_year_filter)
 
         # Test filtering for years 2021-2022
-        assert reader._filter_year_by_filepath(
+        assert reader._is_filepath_in_year_range(
             Path("2021/contributions.csv"), 2021, 2022
         )
-        assert reader._filter_year_by_filepath(
+        assert reader._is_filepath_in_year_range(
             Path("2022/contributions.csv"), 2021, 2022
         )
-        assert not reader._filter_year_by_filepath(
+        assert not reader._is_filepath_in_year_range(
             Path("2020/contributions.csv"), 2021, 2022
         )
-        assert not reader._filter_year_by_filepath(
+        assert not reader._is_filepath_in_year_range(
             Path("2023/contributions.csv"), 2021, 2022
         )
 
@@ -383,13 +383,13 @@ class TestDataReaderYearFiltering:
         """Test filtering with only start year"""
         reader = DataReader(mock_config_handler_with_year_filter)
 
-        assert reader._filter_year_by_filepath(
+        assert reader._is_filepath_in_year_range(
             Path("2022/contributions.csv"), 2022, None
         )
-        assert reader._filter_year_by_filepath(
+        assert reader._is_filepath_in_year_range(
             Path("2023/contributions.csv"), 2022, None
         )
-        assert not reader._filter_year_by_filepath(
+        assert not reader._is_filepath_in_year_range(
             Path("2021/contributions.csv"), 2022, None
         )
 
@@ -399,13 +399,13 @@ class TestDataReaderYearFiltering:
         """Test filtering with only end year"""
         reader = DataReader(mock_config_handler_with_year_filter)
 
-        assert reader._filter_year_by_filepath(
+        assert reader._is_filepath_in_year_range(
             Path("2020/contributions.csv"), None, 2021
         )
-        assert reader._filter_year_by_filepath(
+        assert reader._is_filepath_in_year_range(
             Path("2021/contributions.csv"), None, 2021
         )
-        assert not reader._filter_year_by_filepath(
+        assert not reader._is_filepath_in_year_range(
             Path("2022/contributions.csv"), None, 2021
         )
 
@@ -420,8 +420,8 @@ class TestDataReaderYearFiltering:
 
         reader = DataReader(mock_handler)
 
-        assert reader._filter_year_by_filepath(Path("file1.csv"), 2021, 2022) is True
-        assert reader._filter_year_by_filepath(Path("file2.csv"), 2021, 2022) is True
+        assert reader._is_filepath_in_year_range(Path("file1.csv"), 2021, 2022) is True
+        assert reader._is_filepath_in_year_range(Path("file2.csv"), 2021, 2022) is True
 
     def test_filter_year_by_column(
         self, mock_config_handler_with_year_filter, year_filtered_data
@@ -430,7 +430,9 @@ class TestDataReaderYearFiltering:
         reader = DataReader(mock_config_handler_with_year_filter)
 
         # Test filtering for years 2021-2022
-        filtered_data = reader._filter_year_by_column(year_filtered_data, 2021, 2022)
+        filtered_data = reader._filter_dataframe_to_year_range(
+            year_filtered_data, 2021, 2022
+        )
         expected_years = [2021, 2022]
         assert list(filtered_data["EYEAR"]) == expected_years
 
@@ -440,7 +442,9 @@ class TestDataReaderYearFiltering:
         """Test filtering with only start year"""
         reader = DataReader(mock_config_handler_with_year_filter)
 
-        filtered_data = reader._filter_year_by_column(year_filtered_data, 2022, None)
+        filtered_data = reader._filter_dataframe_to_year_range(
+            year_filtered_data, 2022, None
+        )
         expected_years = [2022, 2023]
         assert list(filtered_data["EYEAR"]) == expected_years
 
@@ -450,7 +454,9 @@ class TestDataReaderYearFiltering:
         """Test filtering with only end year"""
         reader = DataReader(mock_config_handler_with_year_filter)
 
-        filtered_data = reader._filter_year_by_column(year_filtered_data, None, 2021)
+        filtered_data = reader._filter_dataframe_to_year_range(
+            year_filtered_data, None, 2021
+        )
         expected_years = [2020, 2021]
         assert list(filtered_data["EYEAR"]) == expected_years
 
@@ -465,7 +471,9 @@ class TestDataReaderYearFiltering:
 
         reader = DataReader(mock_handler)
 
-        filtered_data = reader._filter_year_by_column(year_filtered_data, 2021, 2022)
+        filtered_data = reader._filter_dataframe_to_year_range(
+            year_filtered_data, 2021, 2022
+        )
         pd.testing.assert_frame_equal(filtered_data, year_filtered_data)
 
     def test_filter_year_by_column_missing_column(
@@ -480,7 +488,9 @@ class TestDataReaderYearFiltering:
             }
         )
 
-        filtered_data = reader._filter_year_by_column(data_without_year, 2021, 2022)
+        filtered_data = reader._filter_dataframe_to_year_range(
+            data_without_year, 2021, 2022
+        )
         pd.testing.assert_frame_equal(filtered_data, data_without_year)
 
     @patch("pandas.read_csv")

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -35,7 +35,7 @@ def test_add_uuids_to_table(sample_table):
 def test_map_ids_to_uuids(sample_table):
     """Test that IDs are replaced if found in the mapping"""
     id_mapping = {
-        (1, 2023, "CA", "tableA"): "11111111-1111-4111-8111-111111111111",
+        ("1", 2023, "CA", "tableA"): "11111111-1111-4111-8111-111111111111",
         ("invalid_uuid", 2022, "NY", "tableA"): "22222222-2222-4222-8222-222222222222",
     }
     map_ids_to_uuids(sample_table, "tableA", id_mapping, "id")
@@ -77,12 +77,13 @@ def test_handle_id_column(sample_table):
     mock_schema.table_name = "tableA"
 
     id_mapping = {
-        (1, 2023, "CA", "tableA"): "11111111-1111-4111-8111-111111111111",
+        ("1", 2023, "CA", "tableA"): "11111111-1111-4111-8111-111111111111",
     }
     handle_id_column(sample_table, mock_schema, id_mapping, "id")
 
     assert (
-        id_mapping[(1, 2023, "CA", "tableA")] == "11111111-1111-4111-8111-111111111111"
+        id_mapping[("1", 2023, "CA", "tableA")]
+        == "11111111-1111-4111-8111-111111111111"
     ), "Old mappings should remain"
     expected_id_mapping_length = 2
     assert re.match(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,286 @@
+import pandas as pd
+import pytest
+from utils.io import load_database, load_table_chunked, save_database
+
+
+@pytest.fixture
+def sample_database():
+    """Create sample database for testing."""
+    return {
+        "transactions": pd.DataFrame(
+            {
+                "id": [1, 2, 3, 4, 5],
+                "amount": [100.0, 200.0, 150.0, 300.0, 250.0],
+                "date": [
+                    "2023-01-01",
+                    "2023-01-02",
+                    "2023-01-03",
+                    "2023-01-04",
+                    "2023-01-05",
+                ],
+                "description": [
+                    "Purchase A",
+                    "Purchase B",
+                    "Purchase C",
+                    "Purchase D",
+                    "Purchase E",
+                ],
+            }
+        ),
+        "accounts": pd.DataFrame(
+            {
+                "account_id": [1, 2, 3],
+                "account_name": ["Checking", "Savings", "Investment"],
+                "balance": [1000.0, 5000.0, 10000.0],
+            }
+        ),
+    }
+
+
+@pytest.fixture
+def large_sample_database():
+    """Create larger sample database for chunking tests."""
+    return {
+        "large_table": pd.DataFrame(
+            {
+                "id": range(1, 101),
+                "value": [f"value_{i}" for i in range(1, 101)],
+                "amount": [i * 10.5 for i in range(1, 101)],
+            }
+        )
+    }
+
+
+@pytest.fixture
+def indexed_database():
+    """Create database with named index for testing index handling."""
+    transactions = pd.DataFrame(
+        {
+            "transaction_id": [1, 2, 3],
+            "amount": [100.0, 200.0, 150.0],
+            "type": ["debit", "credit", "debit"],
+        }
+    )
+    transactions = transactions.set_index("transaction_id")
+
+    return {"indexed_transactions": transactions}
+
+
+def test_save_and_load_database_csv(tmp_path, sample_database):
+    """Test saving and loading database in CSV format."""
+    save_database(sample_database, tmp_path, format="csv")
+
+    # Verify files were created
+    assert (tmp_path / "transactions.csv").exists()
+    assert (tmp_path / "accounts.csv").exists()
+
+    # Load and verify
+    loaded_db = load_database(tmp_path, format="csv")
+
+    assert set(loaded_db.keys()) == {"transactions", "accounts"}
+    pd.testing.assert_frame_equal(
+        loaded_db["transactions"], sample_database["transactions"]
+    )
+    pd.testing.assert_frame_equal(loaded_db["accounts"], sample_database["accounts"])
+
+
+def test_save_and_load_database_parquet(tmp_path, sample_database):
+    """Test saving and loading database in Parquet format."""
+    save_database(sample_database, tmp_path, format="parquet")
+
+    # Verify files were created
+    assert (tmp_path / "transactions.parquet").exists()
+    assert (tmp_path / "accounts.parquet").exists()
+
+    # Load and verify
+    loaded_db = load_database(tmp_path, format="parquet")
+
+    assert set(loaded_db.keys()) == {"transactions", "accounts"}
+    pd.testing.assert_frame_equal(
+        loaded_db["transactions"], sample_database["transactions"]
+    )
+    pd.testing.assert_frame_equal(loaded_db["accounts"], sample_database["accounts"])
+
+
+def test_save_database_creates_directory(tmp_path, sample_database):
+    """Test that save_database creates output directory if it doesn't exist."""
+    output_path = tmp_path / "new_directory"
+    assert not output_path.exists()
+
+    save_database(sample_database, output_path, format="csv")
+
+    assert output_path.exists()
+    assert (output_path / "transactions.csv").exists()
+
+
+def test_load_database_empty_directory(tmp_path):
+    """Test loading from empty directory returns empty dict."""
+    result = load_database(tmp_path, format="csv")
+    assert result == {}
+
+
+def test_load_database_mixed_files(tmp_path, sample_database):
+    """Test loading ignores files with wrong extension."""
+    save_database(sample_database, tmp_path, format="csv")
+
+    # Add file with wrong extension
+    (tmp_path / "other_file.txt").write_text("not a csv")
+
+    loaded_db = load_database(tmp_path, format="csv")
+    assert set(loaded_db.keys()) == {"transactions", "accounts"}
+
+
+def test_save_database_append_mode_csv(tmp_path):
+    """Test appending to existing CSV files."""
+    # Save initial data
+    initial_data = {"test_table": pd.DataFrame({"id": [1, 2], "value": ["a", "b"]})}
+    save_database(initial_data, tmp_path, format="csv", mode="overwrite")
+
+    # Append additional data
+    additional_data = {"test_table": pd.DataFrame({"id": [3, 4], "value": ["c", "d"]})}
+    save_database(additional_data, tmp_path, format="csv", mode="append")
+
+    # Verify combined result
+    loaded_db = load_database(tmp_path, format="csv")
+    expected = pd.DataFrame({"id": [1, 2, 3, 4], "value": ["a", "b", "c", "d"]})
+    pd.testing.assert_frame_equal(loaded_db["test_table"], expected)
+
+
+def test_save_database_append_mode_parquet(tmp_path):
+    """Test appending to existing Parquet files."""
+    # Save initial data
+    initial_data = {"test_table": pd.DataFrame({"id": [1, 2], "value": ["a", "b"]})}
+    save_database(initial_data, tmp_path, format="parquet", mode="overwrite")
+
+    # Append additional data
+    additional_data = {"test_table": pd.DataFrame({"id": [3, 4], "value": ["c", "d"]})}
+    save_database(additional_data, tmp_path, format="parquet", mode="append")
+
+    # Verify combined result
+    loaded_db = load_database(tmp_path, format="parquet")
+    expected = pd.DataFrame({"id": [1, 2, 3, 4], "value": ["a", "b", "c", "d"]})
+    pd.testing.assert_frame_equal(loaded_db["test_table"], expected)
+
+
+def test_save_database_overwrite_mode(tmp_path):
+    """Test overwriting existing files."""
+    # Save initial data
+    initial_data = {
+        "test_table": pd.DataFrame({"id": [1, 2], "value": ["old", "data"]})
+    }
+    save_database(initial_data, tmp_path, format="csv")
+
+    # Overwrite with new data
+    new_data = {"test_table": pd.DataFrame({"id": [3, 4], "value": ["new", "data"]})}
+    save_database(new_data, tmp_path, format="csv", mode="overwrite")
+
+    # Verify only new data exists
+    loaded_db = load_database(tmp_path, format="csv")
+    pd.testing.assert_frame_equal(loaded_db["test_table"], new_data["test_table"])
+
+
+def test_indexed_dataframe_handling(tmp_path, indexed_database):
+    """Test handling of DataFrames with named indices."""
+    save_database(indexed_database, tmp_path, format="csv")
+
+    loaded_db = load_database(tmp_path, format="csv")
+
+    # CSV should preserve the index as a column
+    expected_columns = {"transaction_id", "amount", "type"}
+    assert set(loaded_db["indexed_transactions"].columns) == expected_columns
+
+
+def test_load_database_chunked_csv(tmp_path, large_sample_database):
+    """Test chunked loading with CSV format."""
+    save_database(large_sample_database, tmp_path, format="csv")
+
+    chunks = list(load_database(tmp_path, format="csv", chunk_size=25))
+
+    # Should have 4 chunks (100 rows / 25 chunk_size)
+    assert len(chunks) == 4
+
+    # Verify each chunk has the expected structure
+    for chunk_db in chunks:
+        assert "large_table" in chunk_db
+        assert len(chunk_db["large_table"]) <= 25
+
+    # Verify total rows when concatenated
+    all_chunks = pd.concat(
+        [chunk["large_table"] for chunk in chunks], ignore_index=True
+    )
+    assert len(all_chunks) == 100
+
+
+def test_load_database_chunked_parquet(tmp_path, large_sample_database):
+    """Test chunked loading with Parquet format."""
+    save_database(large_sample_database, tmp_path, format="parquet")
+
+    chunks = list(load_database(tmp_path, format="parquet", chunk_size=30))
+
+    # Should have 4 chunks (100 rows / 30 chunk_size, with remainder)
+    assert len(chunks) == 4
+
+    # Verify chunk sizes
+    chunk_sizes = [len(chunk["large_table"]) for chunk in chunks]
+    assert chunk_sizes == [30, 30, 30, 10]
+
+
+def test_load_table_chunked_csv(tmp_path, large_sample_database):
+    """Test loading single table in chunks from CSV."""
+    save_database(large_sample_database, tmp_path, format="csv")
+    table_path = tmp_path / "large_table.csv"
+
+    chunks = list(load_table_chunked(table_path, chunk_size=20, format="csv"))
+
+    assert len(chunks) == 5  # 100 rows / 20 chunk_size
+
+    # Verify total rows
+    total_rows = sum(len(chunk) for chunk in chunks)
+    assert total_rows == 100
+
+
+def test_load_table_chunked_parquet(tmp_path, large_sample_database):
+    """Test loading single table in chunks from Parquet."""
+    save_database(large_sample_database, tmp_path, format="parquet")
+    table_path = tmp_path / "large_table.parquet"
+
+    chunks = list(load_table_chunked(table_path, chunk_size=15, format="parquet"))
+
+    assert len(chunks) == 7  # 100 rows / 15 chunk_size (with remainder)
+
+    # Verify chunk sizes
+    chunk_sizes = [len(chunk) for chunk in chunks]
+    assert chunk_sizes == [15, 15, 15, 15, 15, 15, 10]
+
+
+def test_load_database_chunked_multiple_tables(tmp_path, sample_database):
+    """Test chunked loading handles multiple tables correctly."""
+    save_database(sample_database, tmp_path, format="csv")
+
+    chunks = list(load_database(tmp_path, format="csv", chunk_size=2))
+
+    # Should process both tables in chunks
+    assert len(chunks) == 3  # Max(5/2, 3/2) = 3 chunks needed
+
+    for chunk_db in chunks:
+        # Each chunk should contain data from available tables
+        if "transactions" in chunk_db:
+            assert len(chunk_db["transactions"]) <= 2
+        if "accounts" in chunk_db:
+            assert len(chunk_db["accounts"]) <= 2
+
+
+def test_load_database_no_matching_files(tmp_path):
+    """Test loading database when no files match the format."""
+    # Create files with wrong extensions
+    (tmp_path / "data.txt").write_text("not a csv")
+    (tmp_path / "other.json").write_text("{}")
+
+    result = load_database(tmp_path, format="csv")
+    assert result == {}
+
+
+def test_load_database_chunked_empty_directory(tmp_path):
+    """Test chunked loading from empty directory."""
+    chunks = list(load_database(tmp_path, format="csv", chunk_size=10))
+    assert chunks == []


### PR DESCRIPTION
This PR will close #122 and #120

Main things to note:

- Added ability to filter by year when standardizing. There's two ways to configure this: either by a column name or by a filepath regex. This is because some states store their data all in one file with a year column and some do one file per year. This approach allows both of these. 
- added ability to specify path of raw data directory. This required moving the computation of paths that meet the expected form type regex out of the config class. It's cleaner this way anyway I think. 
- Created ability to save and load by chunks. Required tracking id mappings (we remap state provided ids to uuids) accross chunks
- Ability to save as parquet
